### PR TITLE
Support numerical keycap emoji by including 2 byte runes

### DIFF
--- a/search.go
+++ b/search.go
@@ -7,7 +7,7 @@ import (
 	"github.com/tmdvs/Go-Emoji-Utils/utils"
 )
 
-// SearchResult - Occurence of an emoji in a string
+// SearchResult - Occurrence of an emoji in a string
 type SearchResult struct {
 	Match       interface{}
 	Occurrences int
@@ -28,7 +28,7 @@ func (results SearchResults) IndexOf(result interface{}) int {
 	return -1
 }
 
-// Find a specific emoji character within a srting
+// Find a specific emoji character within a string
 func Find(emojiString string, input string) (result SearchResult, err error) {
 
 	// Firstly we'll grab the emoji record for the emoji we're looking for
@@ -65,7 +65,7 @@ func FindAll(input string) (detectedEmojis SearchResults) {
 	// Loop over each "word" in the string
 	for index, r := range runes {
 
-		// If this index has been flaged as a modifier we do
+		// If this index has been flagged as a modifier we do
 		// not want to process it again
 		if detectedModifiers[index] {
 			continue
@@ -75,8 +75,8 @@ func FindAll(input string) (detectedEmojis SearchResults) {
 		hexKey := utils.RunesToHexKey([]rune{r})
 
 		// Ignore any basic runes, we'll get funny partials
-		// that we dont care about
-		if len(hexKey) < 4 {
+		// that we don't care about
+		if len(hexKey) < 2 {
 			continue
 		}
 
@@ -93,13 +93,13 @@ func FindAll(input string) (detectedEmojis SearchResults) {
 			if len(potentialMatches) == 1 {
 				break
 			} else if len(potentialMatches) == 0 {
-				// We didnt find anything, so we'll check if its a single rune emoji
+				// We didn't find anything, so we'll check if its a single rune emoji
 				// Reset to original hexKey
 				if _, match := Emojis[previousKey]; match {
 					potentialMatches[previousKey] = Emojis[previousKey]
 				}
 
-				// Definately no modifiers
+				// Definitely no modifiers
 				detectedModifiers = map[int]bool{}
 
 				break
@@ -138,7 +138,7 @@ func FindAll(input string) (detectedEmojis SearchResults) {
 						Match:       e,
 						Occurrences: 1,
 						Locations: [][]int{
-							[]int{index, index + emojiRuneLength},
+							{index, index + emojiRuneLength},
 						},
 					})
 				}

--- a/tests/search_test.go
+++ b/tests/search_test.go
@@ -49,6 +49,14 @@ func TestContinuousEmoji(t *testing.T) {
 	assert.Equal(t, "abc", emojiRemoved, "There should be no emoji")
 }
 
+func TestNumericalKeycaps(t *testing.T) {
+	str := "0️⃣1️⃣2️⃣3️⃣4️⃣5️⃣6️⃣7️⃣8️⃣9️⃣🔟"
+	matches := emoji.FindAll(str)
+	totalUniqueEmoji := len(matches)
+
+	assert.Equal(t, 11, totalUniqueEmoji, "There should be 11 unique emoji")
+}
+
 func TestRemoveAllEmojiChinese(t *testing.T) {
 
 	str := "起坎特在🇫🇷队的作用更      哈哈哈"


### PR DESCRIPTION
Previously any runes that were less than 4 bytes in length would be ignored. However, keycap emojis (1️⃣ 2️⃣ 3️⃣ … etc) are prefixed with 2 bytes, eg `31-FE0F-20E3`.

As a fix, I've tweaked the search to skip any runes less than 2 bytes instead of 4