### PR TITLE
Better support for emoji with zero width connectors

### DIFF
--- a/emoji.go
+++ b/emoji.go
@@ -86,7 +86,7 @@ func RemoveAll(input string) string {
 	matches := FindAll(input)
 
 	for _, item := range matches {
-		emo := item.Match.(Emoji)
+		emo := item.Match
 		rs := []rune(emo.Value)
 		for _, r := range rs {
 			input = strings.ReplaceAll(input, string([]rune{r}), "")

--- a/search.go
+++ b/search.go
@@ -9,7 +9,7 @@ import (
 
 // SearchResult - Occurrence of an emoji in a string
 type SearchResult struct {
-	Match       interface{}
+	Match       Emoji
 	Occurrences int
 	Locations   [][]int
 }
@@ -43,7 +43,7 @@ func Find(emojiString string, input string) (result SearchResult, err error) {
 	// Loop through emoji present in input and if any match the
 	// emoji we're looking for we'll return the result
 	for _, r := range allEmoji {
-		if r.Match.(Emoji).Key == emoji.Key {
+		if r.Match.Key == emoji.Key {
 			result = r
 			return
 		}
@@ -69,6 +69,15 @@ func FindAll(input string) (detectedEmojis SearchResults) {
 		// not want to process it again
 		if detectedModifiers[index] {
 			continue
+		}
+
+		// If the previous rune was a zero width joiner we'll skip this one
+		// [Github issue](https://github.com/tmdvs/Go-Emoji-Utils/issues/12#issuecomment-1362747872)
+		if index >= 1 {
+			previousRune := []rune{runes[index-1]}
+			if isRuneZeroWidthJoiner(previousRune) {
+				continue
+			}
 		}
 
 		// Grab the initial hex value of this run
@@ -161,4 +170,8 @@ func findEmoji(term string, list map[string]Emoji) (results map[string]Emoji) {
 		}
 	}
 	return
+}
+
+func isRuneZeroWidthJoiner(r []rune) bool {
+	return utils.RunesToHexKey(r) == "200D"
 }

--- a/tests/search_test.go
+++ b/tests/search_test.go
@@ -31,6 +31,9 @@ func TestRemoveAllEmoji(t *testing.T) {
 	totalUniqueEmoji := len(matches)
 
 	assert.Equal(t, totalUniqueEmoji, 6, "There should be six different emoji, found: %v", matches)
+	assert.Equal(t, matches[0].Match.Value, "😄", "The first emoji should be 😄")
+	assert.Equal(t, matches[1].Match.Value, "🐷", "The second emoji should be 🐷")
+	assert.Equal(t, matches[5].Match.Value, "🥰", "The second emoji should be 🥰")
 
 	emojiRemoved := emoji.RemoveAll(str)
 	assert.Equal(t, "This is a string with some emoji!", emojiRemoved, "There should be no emoji")
@@ -57,6 +60,14 @@ func TestNumericalKeycaps(t *testing.T) {
 	assert.Equal(t, 11, totalUniqueEmoji, "There should be 11 unique emoji")
 }
 
+func TestFamilyEmoji(t *testing.T) {
+	str := "👨‍👩‍👦‍👦family emoji"
+	matches := emoji.FindAll(str)
+	totalUniqueEmoji := len(matches)
+
+	assert.Equal(t, 1, totalUniqueEmoji, "There should be 1 unique emoji")
+}
+
 func TestRemoveAllEmojiChinese(t *testing.T) {
 
 	str := "起坎特在🇫🇷队的作用更      哈哈哈"
@@ -65,6 +76,7 @@ func TestRemoveAllEmojiChinese(t *testing.T) {
 	totalUniqueEmoji := len(matches)
 
 	assert.Equal(t, totalUniqueEmoji, 1, "There should be one emoji")
+	assert.Equal(t, matches[0].Match.Value, "🇫🇷", "The emoji should be 🇫🇷")
 
 	emojiRemoved := emoji.RemoveAll(str)
 	assert.Equal(t, "起坎特在队的作用更 哈哈哈", emojiRemoved, "There should be no emoji")
@@ -79,6 +91,8 @@ func TestRemoveAllEmojiChineseEnglishMixed(t *testing.T) {
 	totalUniqueEmoji := len(matches)
 
 	assert.Equal(t, totalUniqueEmoji, 8, "There should be one emoji")
+	assert.Equal(t, matches[0].Match.Value, "🤮", "The first emoji should be 🤮")
+	assert.Equal(t, matches[4].Match.Value, "🤠", "The fifth emoji should be 🤠")
 
 	emojiRemoved := emoji.RemoveAll(str)
 	assert.Equal(t, "wo武斌ello a武斌 g ood peoello", emojiRemoved, "There should be no emoji")


### PR DESCRIPTION
The [zero-width connector](https://emojipedia.org/zero-width-joiner#technical) is a special character used to combine multiple emoji into a single emoji character on screen. For example 👩‍👩‍👧‍👧

This patches the code to skip specific instances of the zero-width connector to avoid parsing parts of the emoji as unicode characters/breaking into multiple emoji.

This is based on https://github.com/tmdvs/Go-Emoji-Utils/issues/12#issuecomment-1362747872